### PR TITLE
'MessageReactions.clear()' wasn't working.

### DIFF
--- a/DiscordBot/src/commands/djsCommand.ts
+++ b/DiscordBot/src/commands/djsCommand.ts
@@ -50,8 +50,8 @@ export default class DjsCommand extends BaseCommand {
                         });
 
                         collector.on('end', r => {
-                            if (r.size <= 0) {
-                                (m as Discord.Message).reactions.deleteAll();
+                            if ((r.size - 1) <= 0) {
+                                (m as Discord.Message).reactions.clear();
                             }
                         });
                     });

--- a/DiscordBot/src/commands/djsCommand.ts
+++ b/DiscordBot/src/commands/djsCommand.ts
@@ -51,7 +51,7 @@ export default class DjsCommand extends BaseCommand {
 
                         collector.on('end', r => {
                             if (r.size <= 0) {
-                                (m as Discord.Message).reactions.clear();
+                                (m as Discord.Message).reactions.deleteAll();
                             }
                         });
                     });


### PR DESCRIPTION
I've made an over-look on the 'MessageReactions.clear()' method, it for some reason did not work, as a result; I have decided to open this PR in order to switch it from 'MessageReactions.clear()' to 'MessageReactions.deleteAll()' which should work, as it has been tested on my part.

[ x ] This PR includes changes to the Bot (commands, events, code in general).
[ ] This PR includes changes to the API