### PR TITLE
Add more elements without the flag syntax

### DIFF
--- a/DiscordBot/src/commands/djsCommand.ts
+++ b/DiscordBot/src/commands/djsCommand.ts
@@ -26,7 +26,7 @@ export default class DjsCommand extends BaseCommand {
         let v = 'stable';
 
         if (['--stable', '--master', '--commando', 'master', 'stable', 'commando'].includes(flag)) {
-            v = flag.substr(2);
+            v = flag.includes('--') ? flag.substr(2) : flag;
         } else {
             args.push(flag);
         }

--- a/DiscordBot/src/commands/djsCommand.ts
+++ b/DiscordBot/src/commands/djsCommand.ts
@@ -25,7 +25,7 @@ export default class DjsCommand extends BaseCommand {
 
         let v = 'stable';
 
-        if (['--stable', '--master', '--commando'].includes(flag)) {
+        if (['--stable', '--master', '--commando', 'master', 'stable', 'commando'].includes(flag)) {
             v = flag.substr(2);
         } else {
             args.push(flag);


### PR DESCRIPTION
This PR proposes a change so that the Members of the Guild don't have to use the flag syntax; `--`, in order to get their specified version of Discord.JS.