### PR TITLE
Add a 'tag' command

### DIFF
--- a/DiscordBot/src/commands/tagCommand.ts
+++ b/DiscordBot/src/commands/tagCommand.ts
@@ -1,0 +1,36 @@
+import * as Discord from "discord.js";
+import { IBotCommandHelp } from "../api";
+import BaseCommand from "../baseCommand";
+import { CommandData } from "../models/commandData";
+import { ApiRequestHandler } from "../handlers/apiRequestHandler";
+import { Ticket } from "../models/ticket/ticket";
+import { TicketCreatedEvent } from "../events/shared/ticketCreated";
+import { TicketReceive } from "../models/ticket/ticketReceive";
+import { TicketHelper } from "../helpers/ticketHelper";
+
+export default class MirrorCommand extends BaseCommand {
+    readonly commandWords = ["tag"];
+
+    public getHelp(): IBotCommandHelp {
+        return {
+            caption: "?tag {tag}",
+            description: "Command was made to help H2Hs inform other individuals on what the course of action is in some scenarios.",
+            roles: ["teacher", "dapper coding", "moderator"]
+        };
+    }
+
+    public async process(commandData: CommandData) {
+
+        if (!commandData.message.content.split(" ").slice(1).length) return;
+
+        if (['hastebin', 'pastecode'].some(r => commandData.message.content.toLowerCase().split(" ")[1] === r.toLowerCase())) {
+            commandData.message.channel.send(`To share your long snippets of code, you can use: 
+            \`hastebin\`: https://www.hastebin.com
+            \`hasteb.in\`: https://www.hasteb.in
+            \`hatebin\`: https://www.hatebin.com`);
+        } 
+        else if (commandData.message.content.toLowerCase().split(" ")[1] === 'ask') {
+            commandData.message.channel.send(`Don't ask to ask, just ask! Someone will respond if they know how to help you`);
+        }
+    }
+}


### PR DESCRIPTION
This PR proposes an addition of a new file (new command) in order to make life easier for Teachers.
The command is used to tell some individuals what the course of action is suppose to be in some scenarios (when people don't know where to post long snippets of code, when they ask for help, etc).

[x] Changes have been tested against the latest commit of discord.js@11.5.1 (stable)
[ ] Command is experimental; some parts may or may not work.
[ ] Databases have been handled successfully and prompts like `add`, `remove`, `find`, (...) have been added and are correspondent with said databases.