### PR TITLE
Change how suggestionDialogue handles input

### DIFF
--- a/DiscordBot/src/commands/suggestCommand.ts
+++ b/DiscordBot/src/commands/suggestCommand.ts
@@ -48,16 +48,6 @@ export default class SuggestCommand extends BaseCommand {
       commandData.message
     );
 
-    let suggestionCategoryStep: DialogueStep<
-      SuggestionDialogueData
-    > = new DialogueStep(
-      collectedInfo,
-      dialogue.addCategory,
-      "Enter the category that best suits your suggestion. Choose from 'Bot', 'Website', 'General' or 'Youtube'.",
-      "Type Successful",
-      "Type Unsuccessful"
-    );
-
     let suggestionStep: DialogueStep<SuggestionDialogueData> = new DialogueStep(
       collectedInfo,
       dialogue.addDescription,
@@ -67,7 +57,7 @@ export default class SuggestCommand extends BaseCommand {
     );
 
     let handler = new DialogueHandler(
-      [suggestionCategoryStep, suggestionStep],
+      [suggestionStep],
       collectedInfo
     );
 

--- a/DiscordBot/src/handlers/dialogueHandler.ts
+++ b/DiscordBot/src/handlers/dialogueHandler.ts
@@ -70,9 +70,11 @@ export class DialogueHandler<T> {
         let message = new Discord.RichEmbed()
           .setTitle("Hi " + user.username)
           .setDescription(step.beforeMessage)
-          .addField("Notification for", user)
           .setColor(Constants.EmbedColors.YELLOW)
           .setFooter("You can cancel the process by responding with ?cancel");
+
+        if (this._channel.type !== 'dm') message.addField("Notification for", user);
+        
 
         // Send before discordMessage
         await channel.send(message).then(newMsg => {

--- a/DiscordBot/src/models/suggest.ts
+++ b/DiscordBot/src/models/suggest.ts
@@ -12,7 +12,7 @@ export enum SuggestionTypes {
     Bot = 0,
     Website = 1,
     General = 2,
-    Youtube = 3,
+    YouTube = 3,
     Undecided = 4
 }
 


### PR DESCRIPTION
This PR proposes a change to the following files:
`/models/suggest.ts`,
`/dialogues/suggestionDialogue.ts`,
`/commands/suggestCommand.ts`

The `suggestionDialogue` now handles input for the category through reactions.
[ ] Changes have been tested against the latest commit hash of Discord.js
[x] Changes include changes to commands, dialogues, handlers, models, etc.
[x] These changes should be deemed as experimental, as they have not been tested at all.