### PR TITLE
[NEW] Tag dialogues

### DIFF
--- a/DiscordBot/src/commands/tagCommand.ts
+++ b/DiscordBot/src/commands/tagCommand.ts
@@ -1,0 +1,99 @@
+import * as Discord from 'discord.js';
+import BaseCommand from "../baseCommand";
+import { TagDialogue, TagDialogueData, TagReturnData } from '../dialogues/tagDialogue';
+import { IBotCommandHelp } from '../api';
+import { CommandData } from '../models/commandData';
+import { ApiRequestHandler } from '../handlers/apiRequestHandler';
+import { TagBaseDialogueData } from '../dialogues/TagBaseDialogue';
+import { Constants } from '../constants';
+
+export default class tagCommand extends BaseCommand {
+    dialogue: TagDialogue = new TagDialogue();
+
+    readonly commandWords = ["tag"];
+
+    public getHelp(): IBotCommandHelp {
+        return {
+            caption: '?tag',
+            description: 'Returns a tag from the database if found (depending on the action done).'
+        }
+    }
+
+    public async process(cmdData: CommandData): Promise<void> {
+
+        const msg = cmdData.message.content.toLowerCase();
+        const splitted = msg.split(" ");
+        const valueToCheck = splitted[1];
+
+        if (valueToCheck === 'search') return this.searchTag(cmdData.message);
+        if (valueToCheck === 'add') return this.addTag(cmdData.message);
+        if (msg.match(/i\s*d\s*s\s*e\s*a\s*r\s*c\s*h/)) return this.IDSearch(cmdData.message);
+    }
+
+    public async searchTag(message: Discord.Message) {
+
+        const collectedInfo = new TagDialogueData();
+
+        this.dialogue.createNameHandler(
+            collectedInfo,
+            (message.channel as Discord.TextChannel),
+            message.author,
+            (data) => {
+                new ApiRequestHandler(message.client)
+                    .requestAPIWithType<TagDialogueData>("GET", null, `Tag/byName/${data.name}`)
+                    .then((tag) => {
+                        const embed = new Discord.RichEmbed()
+                            .setTitle(tag.name)
+                            .setDescription(tag.answer);
+                        message.channel.send(embed);
+                    })
+            }
+        )
+    }
+
+    public async addTag(message: Discord.Message) {
+
+        const collectedInfo = new TagDialogueData();
+
+        this.dialogue.createHandler(
+            collectedInfo,
+            (message.channel as Discord.TextChannel),
+            message.author,
+            (data) => {
+                new ApiRequestHandler(message.client)
+                    .requestAPIWithType<TagReturnData>("GET", null, `Tag/byName/${data.name}`)
+                    .then((tag) => {
+                        let url = `Tag/${message.author.id}`
+
+                        if (tag != null) {
+                            url += `/${tag.id}`;
+                        }
+
+                        new ApiRequestHandler(message.client)
+                            .requestAPIWithType<TagReturnData>("POST", data, url)
+                            .then((tag) => {
+                                const embed = new Discord.RichEmbed()
+                                    .setTitle("Successfully added "+ tag.name)
+                                    .setDescription(tag.answer);
+                                message.channel.send(embed);
+                            })
+                    })
+
+                
+            }
+        )
+    }
+
+    public async IDSearch(message: Discord.Message) {
+        const id = message.content.split(" ").pop();
+
+        if (id == null || isNaN(parseInt(id))) { return; }
+        new ApiRequestHandler(message.client)
+            .requestAPIWithType<TagReturnData>("GET", null, `Tag/${id}`).then(tag => {
+                const embed = new Discord.RichEmbed()
+                    .setTitle(tag.name)
+                    .setDescription(tag.answer);
+                message.channel.send(embed);
+            })
+    }
+}

--- a/DiscordBot/src/dialogues/TagBaseDialogue.ts
+++ b/DiscordBot/src/dialogues/TagBaseDialogue.ts
@@ -1,0 +1,49 @@
+import * as Discord from 'discord.js';
+import { BaseDialogueData, BaseDialogue } from "./baseDialogue";
+import { ValidationError } from '../error';
+import { FormBaseDialogue, FormBaseDialogueData } from './formBaseDialogue';
+
+export class TagBaseDialogue<T extends TagBaseDialogueData> implements BaseDialogue<T> {
+
+    createHandler(data: T, channel: Discord.TextChannel | Discord.DMChannel, user: Discord.User, callback: (data: T) => void): void {
+        throw new Error("Method not implemented.");
+    }
+
+    nameStep(response: Discord.Message, data: T) {
+        return new Promise<T>((resolve, reject) => {
+            try {
+                if (!response.content.length) return reject(new ValidationError(`You must enter a tag name for this process.`));
+
+
+                data.name = response.content;
+
+                if (data.name.length < 3) return reject(new ValidationError(`You must enter a tag name that is greater than 3 characters in length.`));
+
+                return resolve(data);
+            } catch (e) {
+                return reject(e);
+            }
+        });
+    }
+
+    descStep(response: Discord.Message, data: T) {
+        return new Promise<T>((resolve, reject) => {
+            try {
+                if (!response.content.length) return reject(new ValidationError(`You must enter a tag description for this process.`));
+
+                data.answer = response.content;
+
+                return resolve(data);
+            } catch (e) {
+                return reject(e);
+            }
+        });
+    }
+}
+
+export interface TagBaseDialogueData extends BaseDialogueData {
+    name: string;
+    answer: string;
+}
+
+export class TagBaseDialogueData implements TagBaseDialogueData { }

--- a/DiscordBot/src/dialogues/tagDialogue.ts
+++ b/DiscordBot/src/dialogues/tagDialogue.ts
@@ -39,9 +39,43 @@ export class TagDialogue extends TagBaseDialogue<TagDialogueData> implements Bas
         )
         .then(callback);
     }
+    public async createNameHandler(
+        data: TagDialogueData,
+        channel: Discord.TextChannel,
+        user: Discord.User,
+        callback: (data: TagDialogueData) => void
+    ) {
+        let nameStep: DialogueStep<
+            TagDialogueData
+        > = new DialogueStep<TagDialogueData>(
+            data,
+            this.nameStep,
+            "Which name do you wish to cast on this tag?"
+        );
+
+        let handler = new DialogueHandler(
+            [nameStep],
+            data
+        );
+
+        await handler
+            .getInput(
+                channel,
+                user
+            )
+            .then(callback);
+    }
 }
 
 export interface TagDialogueData extends BaseDialogueData {
     name: string;
     answer: string;
 }
+
+export class TagDialogueData implements TagDialogueData { }
+
+export interface TagReturnData extends TagDialogueData {
+    id:number
+}
+
+export class TagReturnData implements TagReturnData { }

--- a/DiscordBot/src/dialogues/tagDialogue.ts
+++ b/DiscordBot/src/dialogues/tagDialogue.ts
@@ -1,0 +1,47 @@
+import * as Discord from 'discord.js';
+import { BaseDialogueData, BaseDialogue } from './baseDialogue';
+import { DialogueHandler, DialogueStep } from '../handlers/dialogueHandler';
+import { TagBaseDialogue } from './TagBaseDialogue';
+
+export class TagDialogue extends TagBaseDialogue<TagDialogueData> implements BaseDialogue<TagDialogueData>{
+
+    public async createHandler(
+        data: TagDialogueData,
+        channel: Discord.TextChannel,
+        user: Discord.User,
+        callback: (data: TagDialogueData) => void
+    ) {
+        let nameStep: DialogueStep<
+            TagDialogueData
+        > = new DialogueStep<TagDialogueData>(
+            data,
+            this.nameStep,
+            "Which name do you wish to cast on this tag?"
+        );
+
+        let descStep: DialogueStep<
+            TagDialogueData
+        > = new DialogueStep<TagDialogueData>(
+            data,
+            this.descStep,
+            "Which description do you wish to cast on this tag?"
+        );
+
+        let handler = new DialogueHandler(
+            [nameStep, descStep],
+            data
+        );
+
+        await handler 
+        .getInput(
+            channel,
+            user
+        )
+        .then(callback);
+    }
+}
+
+export interface TagDialogueData extends BaseDialogueData {
+    name: string;
+    answer: string;
+}


### PR DESCRIPTION
This PR creates the tag dialogues needed for our `tag` command, including the base of the dialogue itself.

[ ] Changes have been tested against the latest hash of Discord.js
[ ] Changes should be deemed as experimental (AF).